### PR TITLE
Fix string mismatch with groupinstall

### DIFF
--- a/roles/jws/tasks/install/rpm.yml
+++ b/roles/jws/tasks/install/rpm.yml
@@ -36,7 +36,7 @@
     info_msg: "remove {{ jws.rpm }}"
   when:
     - dnf_command is defined
-    - dnf_command != "groupinstall"
+    - dnf_command != "'groupinstall'"
 
 - name: "Perform {{ info_msg }}"
   ansible.builtin.command:


### PR DESCRIPTION
Because of string mismatch it always shows "Perform remove jws5"