### PR TITLE
jws: set 0640 instead of 0600 for configuration files

### DIFF
--- a/roles/jws/tasks/main.yml
+++ b/roles/jws/tasks/main.yml
@@ -144,7 +144,7 @@
         path: "{{ jws_home }}/{{ item }}"
         owner: "{{ jws.user }}"
         group: "{{ jws.group }}"
-        mode: 0600
+        mode: "{{ jws_config_files_mask | default('0640') }}"
       loop:
         - "{{ jws.conf.properties }}"
         - "{{ jws.conf.policy }}"
@@ -170,7 +170,7 @@
         dest: "{{ item.dest }}"
         owner: "{{ jws.user }}"
         group: "{{ jws.group }}"
-        mode: 0600
+        mode: "{{ jws_config_files_mask | default('0640') }}"
       loop:
         - { template: "{{ jws.conf.templates.server }}", dest: "{{ jws_home }}/{{ jws.conf.server }}" }
         - { template: "{{ jws.conf.templates.web }}", dest: "{{ jws_home }}/{{ jws.conf.web }}" }


### PR DESCRIPTION
@sabre1041 @guidograzioli I've added an override variable, because I'm pretty sure this 0600 came from the Common Criteria recommendation. So, some users, may need to change it.