### PR TITLE
Jws validation ds defaults

### DIFF
--- a/molecule/ajp_or_https/converge.yml
+++ b/molecule/ajp_or_https/converge.yml
@@ -7,6 +7,5 @@
     - vars.yml
   collections:
     - middleware_automation.jws
-  tasks:
-    - ansible.builtin.include_role:
-        name: jws
+  roles:
+    - jws

--- a/molecule/ajp_or_https/molecule.yml
+++ b/molecule/ajp_or_https/molecule.yml
@@ -29,8 +29,6 @@ provisioner:
     prepare: prepare.yml
     converge: converge.yml
     verify: verify.yml
-  env:
-    CATALINA_HOME: "/opt/apache-tomcat-9.0.50"
   inventory:
     host_vars:
       localhost:
@@ -38,7 +36,6 @@ provisioner:
       instance:
         jws_listen_ajp_enabled: True
         jws_listen_https_enabled: True
-
 verifier:
   name: ansible
 scenario:

--- a/molecule/ajp_or_https/verify.yml
+++ b/molecule/ajp_or_https/verify.yml
@@ -6,7 +6,6 @@
   vars_files:
     - vars.yml
   vars:
-    jws_home: "/opt/apache-tomcat-{{ tomcat_version }}"
     jws_listen_https_port: 8443
     jws_listen_https_bind_address: localhost
     # ajp config will not work with tomcat and produce errors in catalina.out

--- a/molecule/ajp_or_https/verify.yml
+++ b/molecule/ajp_or_https/verify.yml
@@ -10,6 +10,5 @@
     jws_listen_https_bind_address: localhost
     # ajp config will not work with tomcat and produce errors in catalina.out
     jws_validation_allow_errors_in_catalina_log: True
-  tasks:
-    - include_role:
-        name: jws_validation
+  roles:
+    - jws_validation

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -6,6 +6,5 @@
     - ../../playbooks/vars.yml
   collections:
     - middleware_automation.jws
-  tasks:
-    - ansible.builtin.include_role:
-        name: jws
+  roles:
+    - jws

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -3,11 +3,7 @@
   hosts: all
   vars_files:
     - ../../playbooks/vars.yml
-  vars:
-    jws_home: "/opt/apache-tomcat-{{ tomcat_version }}"
   collections:
     - middleware_automation.jws
-  tasks:
-    - name: "Verify that state is consistent"
-      include_role:
-        name: jws_validation
+  roles:
+    - jws_validation

--- a/molecule/force_install/converge.yml
+++ b/molecule/force_install/converge.yml
@@ -3,11 +3,6 @@
   hosts: all
   collections:
     - middleware_automation.jws
-  pre_tasks:
-    - name: "Set JWS version if resource available"
-      ansible.builtin.set_fact:
-        jws_version: "5.6.0"
-      when: "'/opt/webserver/5.6.0/jws-5.6.0-application-server.zip' is exists"
   roles:
     - role: jws
       jws_setup: true

--- a/molecule/force_install/verify.yml
+++ b/molecule/force_install/verify.yml
@@ -7,14 +7,7 @@
     - name: "Set JWS version if resource available"
       ansible.builtin.set_fact:
         jws_version: "5.6.0"
-        jws_home: /opt/jws-5.6/tomcat
-        jws_service_name: jws5-tomcat
       when: "'/opt/webserver/5.6.0/jws-5.6.0-application-server.zip' is exists"
-    - name: "Set tomcat checks if resource not available"
-      ansible.builtin.set_fact:
-        jws_home: /opt/apache-tomcat-9.0.65
-        jws_service_name: tomcat
-      when: "'/opt/webserver/5.6.0/jws-5.6.0-application-server.zip' is not exists"
   roles:
     - role: jws_validation
       jws_java_version: 11

--- a/molecule/override_server_xml/converge.yml
+++ b/molecule/override_server_xml/converge.yml
@@ -1,6 +1,7 @@
 ---
 - import_playbook: ../../playbooks/playbook.yml
   vars:
+    jws_home: /opt/custom
     jws_conf_templates_server: ./../molecule/override_server_xml/templates/override_server_xml_template.xml.j2
     jws_listen_ajp_enabled: False
     jws_ajp_flush: False

--- a/molecule/override_server_xml/molecule.yml
+++ b/molecule/override_server_xml/molecule.yml
@@ -29,8 +29,6 @@ provisioner:
     prepare: prepare.yml
     converge: converge.yml
     verify: verify.yml
-  env:
-    CATALINA_HOME: "/opt/apache-tomcat-9.0.50"
   inventory:
     host_vars:
       localhost:

--- a/molecule/override_server_xml/verify.yml
+++ b/molecule/override_server_xml/verify.yml
@@ -2,10 +2,9 @@
 - name: Verify
   hosts: all
   vars:
+    jws_home: /opt/custom
     jws_listen_https_port: 8443
     jws_listen_https_bind_address: localhost
-    tomcat_version: 9.0.65
-    jws_home: "/opt/apache-tomcat-{{ tomcat_version }}"
     jvm_route: jvm_route_1
   collections:
     - middleware_automation.jws

--- a/molecule/uninstall/converge.yml
+++ b/molecule/uninstall/converge.yml
@@ -9,6 +9,3 @@
     - include_role:
         name: jws
         tasks_from: uninstall.yml
-      vars:
-        jws_service_name: tomcat
-        jws_home: /opt/apache-tomcat-{{ tomcat_version }}

--- a/molecule/uninstall/molecule.yml
+++ b/molecule/uninstall/molecule.yml
@@ -29,8 +29,6 @@ provisioner:
     prepare: prepare.yml
     converge: converge.yml
     verify: verify.yml
-  env:
-    CATALINA_HOME: "/opt/apache-tomcat-9.0.50"
   inventory:
     host_vars:
       localhost:

--- a/playbooks/playbook.yml
+++ b/playbooks/playbook.yml
@@ -6,6 +6,5 @@
     - vars.yml
   collections:
     - middleware_automation.jws
-  tasks:
-    - ansible.builtin.include_role:
-        name: jws
+  roles:
+    - jws

--- a/roles/jws/tasks/install/zipfiles.yml
+++ b/roles/jws/tasks/install/zipfiles.yml
@@ -10,11 +10,11 @@
 - name: Add zipfile to unarchive list
   ansible.builtin.set_fact:
     zipfiles:
-      - { src: "{{ zipfile_name }}", creates: "{{ jws_home }}/bin" }
+      - { src: "{{ zipfile_name }}", creates: "{{ jws.install_dir }}/{{ zipfile_rootdir }}/bin" }
 
 - name: Add native zipfile to unarchive list
   ansible.builtin.set_fact:
-    zipfiles: "{{ zipfiles + [{'src':jws_native_zipfile, 'creates':jws_home +'/lib/libtcnative-1.so'}] }}"
+    zipfiles: "{{ zipfiles + [{'src':jws_native_zipfile, 'creates': jws.install_dir + '/' + zipfile_rootdir + '/lib/libtcnative-1.so'}] }}"
   when:
     - jws_native
     - jws_native_zipfile is defined
@@ -30,4 +30,20 @@
     mode: 0750
     creates: "{{ item.creates }}"
   loop: "{{ zipfiles }}"
+  register: unarchived_zipfiles
   notify: "Restart Tomcat service"
+
+- name: Configure custom jws_home
+  when:
+    - jws_home != jws.install_dir + '/' + zipfile_rootdir
+    - unarchived_zipfiles.changed
+  block:
+    - name: Move the zipfile extracted directory to custom jws_home
+      ansible.builtin.copy:
+        src: "{{ jws.install_dir }}/{{ zipfile_rootdir }}/"
+        dest: "{{ jws_home }}"
+        owner: "{{ jws.user }}"
+        group: "{{ jws.group }}"
+        remote_src: yes
+        force: yes
+        mode: preserve

--- a/roles/jws/tasks/main.yml
+++ b/roles/jws/tasks/main.yml
@@ -1,25 +1,25 @@
 ---
 # The following is only for upstream: if jws_version is not defined
 # we use the latest version of Apache Tomcat
-- name: "Set defaults values (if jws_version is not provided)"
+- name: "Set default values"
   ansible.builtin.set_fact:
+    zipfile_rootdir: "apache-tomcat-{{ tomcat_version }}"
     zipfile_name: "apache-tomcat-{{ tomcat_version }}.zip"
+    zipfile_url: "https://archive.apache.org/dist/tomcat/tomcat-{{ tomcat_version.split('.')[0] }}/v{{ tomcat_version }}/bin/apache-tomcat-{{ tomcat_version }}.zip"
   when:
     - not jws_version is defined
 
-- name: "Set defaults values (if jws_version is not provided)"
+- name: "Set default values (jws)"
   ansible.builtin.set_fact:
-    zipfile_url: "https://archive.apache.org/dist/tomcat/tomcat-{{ tomcat_version.split('.')[0] }}/v{{ tomcat_version }}/bin/{{ zipfile_name }}"
-    jws_home: "/opt/apache-tomcat-{{ tomcat_version }}/"
+    zipfile_rootdir: "jws-{{ jws_version.split('.')[0] }}.{{ jws_version.split('.')[1] }}/tomcat"
   when:
-    - not jws_version is defined
+    - jws_version is defined
 
-- name: "Set jws_home if not already defined."
+- name: "Set jws_home to {{ jws.install_dir }}/{{ zipfile_rootdir }} if not already defined"
   ansible.builtin.set_fact:
-    jws_home: "{{ jws.install_dir }}/jws-{{ jws_version.split('.')[0] }}.{{ jws_version.split('.')[1] }}/tomcat"
+    jws_home: "{{ jws.install_dir }}/{{ zipfile_rootdir }}"
   when:
     - not jws_home is defined
-    - jws_version is defined
 
 - name: "Check that jws_home has been defined."
   ansible.builtin.assert:

--- a/roles/jws/templates/systemd/service.sh.j2
+++ b/roles/jws/templates/systemd/service.sh.j2
@@ -31,7 +31,7 @@ case "${COMMAND}" in
       options="${options} -Djava.security.manager -Djava.security.policy==${CATALINA_BASE}/conf/catalina.policy"
     fi
     {{ jws_home }}/bin/startup.sh
-    readonly PID=$(ps -F | grep org.apache.catalina.startup.Bootstrap | sed -e '/grep/d' | sed -e 's/^[^ ]* *//' -e 's/  *.*$//')
+    readonly PID=$(ps -F -ww| grep org.apache.catalina.startup.Bootstrap | grep -v grep | awk '{print $2}')
     echo "Tomcat runs with PID: ${PID}"
     echo "${PID}" > "{{ jws_service_pidfile }}"
     ;;

--- a/roles/jws_validation/defaults/main.yml
+++ b/roles/jws_validation/defaults/main.yml
@@ -3,10 +3,11 @@ jws_user: tomcat
 jws_uid: 53
 jws_group: tomcat
 jws_gid: 53
-# Red Hat JWS default home
-# tomcat_home: /opt/jws-5.6/tomcat/
+
 catalina_logfile: logs/catalina.out
 tomcat_version: 9.0.65
+jws_home: "/opt/apache-tomcat-{{ tomcat_version }}/"
+
 jws_service_name: tomcat
 
 jws_listen_http_bind_address: 127.0.0.1

--- a/roles/jws_validation/meta/argument_specs.yml
+++ b/roles/jws_validation/meta/argument_specs.yml
@@ -27,7 +27,7 @@ argument_specs:
                 description: "posix group GID for service"
                 type: "int"
             jws_service_name:
-                default: "tomcat.service"
+                default: "tomcat"
                 description: "Name for the systemd unit"
                 type: "str"
             catalina_logfile:
@@ -37,6 +37,7 @@ argument_specs:
             jws_home:
                 type: "str"
                 description: "home of tomcat/jws installation"
+                default: "/opt/apache-tomcat-{{ tomcat_version }}/"
             jws_listen_ajp_enabled:
                 # line 28 of jws/defaults/main.yml
                 default: "False"
@@ -67,3 +68,21 @@ argument_specs:
                 required: False
                 description: "Whether to check the service is using the specified JVM version"
                 type: "str"
+    downstream:
+        options:
+            jws_version:
+                default: "5.6.0"
+                description: "JWS version to install"
+                type: "str"
+            jws_home:
+                type: "str"
+                description: "home of tomcat/jws installation"
+                default: "/opt/jws-{{ jws_version.split('.')[0] }}.{{ jws_version.split('.')[1] }}/tomcat"
+            jws_service_name:
+                default: "jws5-tomcat"
+                description: "Name for the systemd unit"
+                type: "str"
+            jws_apply_patches:
+                default: False
+                description: "Whether to validate cumulative patch for requested version"
+                type: "bool"

--- a/roles/jws_validation/tasks/jws_version.yml
+++ b/roles/jws_validation/tasks/jws_version.yml
@@ -3,7 +3,7 @@
   ansible.builtin.assert:
     that:
       - jws_validation_version
-      - jws_home
+      - jws_home is defined
     quiet: True
 
 - name: "Load Version files"
@@ -26,4 +26,4 @@
       - version_line | length > 0
       - jws_validation_version in version_line
     quiet: True
-    fail_msg: "Version line '{{ version_line }}' is not defined or does not contains {{ jws_validation_version }}"
+    fail_msg: "Version line '{{ version_line }}' is not defined or does not contain {{ jws_validation_version }}"

--- a/roles/jws_validation/tasks/jws_version.yml
+++ b/roles/jws_validation/tasks/jws_version.yml
@@ -2,7 +2,7 @@
 - name: "Verify that required parameters are provided."
   ansible.builtin.assert:
     that:
-      - jws_validation_version
+      - jws_version
       - jws_home is defined
     quiet: True
 
@@ -19,11 +19,11 @@
   ansible.builtin.set_fact:
     version_line: "{{ version_file_content.splitlines() | first }}"
 
-- name: "Check that version matches {{ jws_validation_version }}"
+- name: "Check that version matches {{ jws_version }}"
   ansible.builtin.assert:
     that:
       - version_line is defined
       - version_line | length > 0
-      - jws_validation_version in version_line
+      - jws_version in version_line
     quiet: True
-    fail_msg: "Version line '{{ version_line }}' is not defined or does not contain {{ jws_validation_version }}"
+    fail_msg: "Version line '{{ version_line }}' is not defined or does not contain {{ jws_version }}"

--- a/roles/jws_validation/tasks/main.yml
+++ b/roles/jws_validation/tasks/main.yml
@@ -25,7 +25,7 @@
 - name: "Check that the version install matches expectation (if requested)."
   ansible.builtin.include_tasks: jws_version.yml
   when:
-    - jws_validation_version is defined
+    - jws_version is defined
 
 - name: "Verify that main server's logfile exists."
   ansible.builtin.include_tasks: catalina_out.yml
@@ -54,8 +54,8 @@
 - name: "Ensure Tomcat AJP connector is started and listen to the appropriate port"
   ansible.builtin.include_tasks: check_connector_port.yml
   vars:
-    bind_address: "{{  jws_listen_ajp_bind_address }}"
-    listen_port: "{{  jws_listen_ajp_port }}"
+    bind_address: "{{ jws_listen_ajp_bind_address }}"
+    listen_port: "{{ jws_listen_ajp_port }}"
   when:
     - jws_listen_ajp_enabled is defined
     - jws_listen_ajp_bind_address is defined


### PR DESCRIPTION
* Fix issue reading PID from very long service cmdlines
* Reduce redundant defaults in molecule, downstream testing
* Make jws_home really configurable