### PR TITLE
Add a check to see if you already have the zipfile downloaded, if so, don't download it again

### DIFF
--- a/roles/jws/tasks/install/url.yml
+++ b/roles/jws/tasks/install/url.yml
@@ -7,6 +7,11 @@
       - zipfile_name is defined
     quiet: True
 
+- name: Check zipfile existence
+  stat:
+    path: "{{ jws_install_dir }}/{{ zipfile_name }}"
+  register: zipfile_dest
+
 - name: Download archive from custom url
   ansible.builtin.get_url:
     url: "{{ zipfile_url }}"
@@ -16,3 +21,4 @@
     mode: 0640
     owner: "{{ jws.user }}"
     group: "{{ jws.group }}"
+  when: not zipfile_dest.stat.exists


### PR DESCRIPTION
In the case of testing tomcat releases the binary doesn't exist in the expected place which produces a `404` by `get_url` and task failure. Since we cannot override the `zipfile_url` we should check to see if the file exists and not download it again if so. Maybe this should be configurable. 