### PR TITLE
README: Remove 'beta' for release and add link to downstream release

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Execution should be successful without errors
 
 ## Support
 
-This collection is a Beta release and for [Technical Preview](https://access.redhat.com/support/offerings/techpreview). If you have any issues or questions related to collection, please don't hesitate to contact us on <Ansible-middleware-core@redhat.com> or open an issue on https://github.com/ansible-middleware/jws/issues
+This collection is released as [Technical Preview](https://access.redhat.com/support/offerings/techpreview) for Red Hat Customer [JWS Ansible Collection](https://console.redhat.com/ansible/automation-hub/repo/published/redhat/jws). If you have any issues or questions related to collection, please don't hesitate to contact us on <Ansible-middleware-core@redhat.com> or open an issue on https://github.com/ansible-middleware/jws/issues
 
 
 ## License


### PR DESCRIPTION
@csutherl As Adam smartly pointed out, we should remove the Beta qualifiers from the README. WDYT? Can we double check the content of this PR, see if it what it should be? 