### PR TITLE
Revert selinux policy postinstall filenames

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -14,6 +14,7 @@ license_file: "LICENSE"
 tags: [java, tomcat, server, apache, jws, modcluster, infrastructure, linux]
 dependencies:
   middleware_automation.redhat_csp_download: '>=1.2.1'
+  community.general: ">=5.6.0"
 repository: https://github.com/ansible-middleware/jws-ansible-playbook
 documentation: https://ansible-middleware.github.io/jws-ansible-playbook
 homepage: https://github.com/ansible-middleware/jws-ansible-playbook

--- a/roles/jws/meta/argument_specs.yml
+++ b/roles/jws/meta/argument_specs.yml
@@ -375,3 +375,7 @@ argument_specs:
                 default: "jws5-tomcat"
                 description: "Name for the systemd unit"
                 type: "str"
+            jws_selinux_enabled:
+                default: True
+                description: "Enable selinux policy enforcement for JWS"
+                type: "bool"

--- a/roles/jws/tasks/systemd/selinux.yml
+++ b/roles/jws/tasks/systemd/selinux.yml
@@ -11,7 +11,7 @@
 
 - name: Check if archive contains a selinux policy
   ansible.builtin.stat:
-    path: "{{ jws_home }}/selinux/jws5-jws.if"
+    path: "{{ jws_home }}/selinux/jws5-tomcat.if"
   register: archive_path_selinux
 
 - name: "Compile and install selinux policy"
@@ -23,14 +23,14 @@
 
     - name: Check if archive contains a selinux policy
       ansible.builtin.stat:
-        path: "{{ jws_home }}/selinux/jws5-jws.pp"
+        path: "{{ jws_home }}/selinux/jws5-tomcat.pp"
       register: policy_path_selinux
 
     - name: Create selinux policy
       ansible.builtin.command: make -f /usr/share/selinux/devel/Makefile
       args:
         chdir: "{{ jws_home }}/selinux"
-        creates: "{{ jws_home }}/selinux/jws5-jws.pp"
+        creates: "{{ jws_home }}/selinux/jws5-tomcat.pp"
       when:
         - not policy_path_selinux.stat.exists
       notify:


### PR DESCRIPTION
#209 

note this won't work in a ubi container since selinux-policy-devel has been removed