### PR TITLE
Use alternatives, not rpm, to determine java_home

### DIFF
--- a/roles/jws/tasks/java_install.yml
+++ b/roles/jws/tasks/java_install.yml
@@ -13,11 +13,6 @@
       vars:
         package_name: "{{ jws_java_packages_el }}"
 
-    - name: Determine JAVA_HOME for selected JVM RPM  # noqa blocked_modules
-      ansible.builtin.shell: |
-        set -o pipefail
-        rpm -ql {{ jws_java_packages_el }} | grep -Po '/usr/lib/jvm/.*(?=/bin/java$)'
-      args:
-        executable: /bin/bash
-      changed_when: False
-      register: rpm_java_home
+- name: Determine JAVA_HOME for selected JVM RPM
+  ansible.builtin.set_fact:
+    rpm_java_home: "/etc/alternatives/jre_{{ jws_java_version }}"

--- a/roles/jws/tasks/java_install.yml
+++ b/roles/jws/tasks/java_install.yml
@@ -13,6 +13,6 @@
       vars:
         package_name: "{{ jws_java_packages_el }}"
 
-- name: Determine JAVA_HOME for selected JVM RPM
-  ansible.builtin.set_fact:
-    rpm_java_home: "/etc/alternatives/jre_{{ jws_java_version }}"
+    - name: Determine JAVA_HOME for selected JVM RPM
+      ansible.builtin.set_fact:
+        rpm_java_home: "/etc/alternatives/jre_{{ jws_java_version }}"

--- a/roles/jws/tasks/systemd/systemd.yml
+++ b/roles/jws/tasks/systemd/systemd.yml
@@ -51,7 +51,7 @@
     group: "{{ jws.group }}"
     mode: 0644
   vars:
-    jws_rpm_java_home: "{{ rpm_java_home.stdout if rpm_java_home is defined else '/usr/lib/jvm/java' }}"
+    jws_rpm_java_home: "{{ rpm_java_home if rpm_java_home is defined else '/usr/lib/jvm/java' }}"
   notify:
     - Systemd reload
     - Ensure Tomcat runs under systemd


### PR DESCRIPTION
This is easier and more reliable, since it supports having the JDK rpm being updated outside the collection.