### PR TITLE
Fix offline patch installation

### DIFF
--- a/roles/jws/tasks/apply_cp/apply_cp.yml
+++ b/roles/jws/tasks/apply_cp/apply_cp.yml
@@ -4,6 +4,27 @@
 
 - name: "Download patches from RHN if requested."
   ansible.builtin.include_tasks: download_from_rhn.yml
+  when: patch_bundle is not defined or patch_bundle | length == 0
+
+- name: "Compute required paths (if patch selected)."
+  block:
+
+    - name: "Set path to patch bundle file archive on target (if not set). Path: /{{ jws_install_dir }}/{{ patch_bundle }}"
+      ansible.builtin.set_fact:
+        path_to_patch_bundle_on_target: "{{ jws_install_dir }}/{{ patch_bundle }}"
+      when:
+        - not path_to_patch_bundle_on_target is defined or 'reset' in path_to_patch_bundle_on_target
+
+    - name: "Set path to patch bundle file archive locally (if not set). Path: {{ jws_archive_repository }}/{{ patch_bundle }}"
+      ansible.builtin.set_fact:
+        downloaded_patch_bundle_file: "{{ jws_archive_repository }}/{{ patch_bundle }}"
+      when:
+        - not downloaded_patch_bundle_file is defined or 'reset' in downloaded_patch_bundle_file
+
+- name: "Set patch version if empty"
+  ansible.builtin.set_fact:
+    patch_version: "{{ patch_bundle | regex_search('\\d+\\.\\d+\\.\\d+') }}"
+  when: patch_version is not defined or patch_version | length == 0
 
 - name: "Verify that patch checksum, if provided, matches."
   ansible.builtin.include_tasks: checksum.yml

--- a/roles/jws/tasks/apply_cp/download_from_rhn.yml
+++ b/roles/jws/tasks/apply_cp/download_from_rhn.yml
@@ -62,18 +62,3 @@
             rhn_product_path: "{{ jws_archive_repository }}/{{ patch_bundle }}"
           when:
             - rhn_filtered_products | length > 0
-
-- name: "Compute required paths (if patch selected)."
-  block:
-
-    - name: "Set path to patch bundle file archive on target (if not set)."
-      ansible.builtin.set_fact:
-        path_to_patch_bundle_on_target: "/opt/{{ patch_bundle }}"
-      when:
-        - not path_to_patch_bundle_on_target is defined or 'reset' in path_to_patch_bundle_on_target
-
-    - name: "Set path to patch bundle file archive locally (if not set)."
-      ansible.builtin.set_fact:
-        downloaded_patch_bundle_file: "{{ jws_archive_repository }}/{{ patch_bundle }}"
-      when:
-        - not downloaded_patch_bundle_file is defined or 'reset' in downloaded_patch_bundle_file

--- a/roles/jws/tasks/apply_cp/perform_update.yml
+++ b/roles/jws/tasks/apply_cp/perform_update.yml
@@ -3,7 +3,7 @@
   when:
     - not last_patch_status.stat.exists
   block:
-    - name: "Update {{ jws_home }} with downloaded Cumulative Patch {{ path_to_patch_bundle_on_target }}."
+    - name: "Update {{ jws_home }} with cumulative patch {{ path_to_patch_bundle_on_target }}."
       ansible.builtin.unarchive:
         src: "{{ path_to_patch_bundle_on_target }}"
         dest: "{{ jws.install_dir }}"

--- a/roles/jws/tasks/apply_cp/prereqs.yml
+++ b/roles/jws/tasks/apply_cp/prereqs.yml
@@ -22,9 +22,9 @@
       - jws_home_state.stat.isdir is defined
       - jws_home_state.stat.isdir
 
-- name: "Ensure patch version is specified when installing offline."
+- name: "Ensure patch zipfile is provided when installing offline."
   ansible.builtin.assert:
     that:
-      - (rhn_username is defined and rhn_password is defined) or (jws_patch_version is defined and jws_patch_version | length > 0)
+      - (rhn_username is defined and rhn_password is defined) or (patch_bundle is defined and patch_bundle | length > 0)
     quiet: True
-    fail_msg: "When applying patches, you need to provide the zipfile and its version in jws_patch_version, or define customer portal credentials to download."
+    fail_msg: "When applying patches, you need to provide the zipfile through patch_bundle variable, or define customer portal credentials to download."


### PR DESCRIPTION
Fix for offline patch installation with zips. 
Tested with the following playbooks:

Apply patch:

- name: "Red Hat JBoss Web Server installation and configuration"
  hosts: all
  become: True
  vars:
    zipfile_name: "jws-5.7.0-application-server.zip"
    jws_apply_patches: True
    patch_bundle: "jws-5.7.4-application-server.zip"
    jws_version: 5.7.0
  roles:
    - jws

Do not apply patch:

- name: "Red Hat JBoss Web Server installation and configuration"
  hosts: all
  become: True
  vars:
    zipfile_name: "jws-5.7.0-application-server.zip"
    jws_apply_patches: False
    patch_bundle: "jws-5.7.4-application-server.zip"
    jws_version: 5.7.0
  roles:
    - jws
