### PR TITLE
Change requires_ansible key to a supported version

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.9.10"
+requires_ansible: ">=2.13.0"


### PR DESCRIPTION
Fixes linting warning: "requires_ansible key must be set to a supported version".