### PR TITLE
AMW-133 [JWS] Allow automatic recognition of Java

### DIFF
--- a/roles/jws/README.md
+++ b/roles/jws/README.md
@@ -149,12 +149,13 @@ Role Defaults
 Role Variables
 --------------
 
-| Variable           | Description                                                                        | Required |
-|:-------------------|:-----------------------------------------------------------------------------------|:---------|
-| `jws_java_version` | Version of java openjdk RPM to install for Tomcat, by default nothing is installed | `No`     |
-| `jws_java_home`    | Path to the JAVA\_HOME to be used by the server                                    | `No`     |
+| Variable           | Description                                                                        |
+|:-------------------|:-----------------------------------------------------------------------------------|
+| `jws_java_version` | Version of java openjdk RPM to install for Tomcat, by default nothing is installed |
+| `jws_java_home`    | Path to the JAVA\_HOME to be used by the server                                    |
 <!--end argument_specs-->
 
+NOTE: You need to provided either `jws_java_version` or `jws_java_home` value. `jws_java_version` value can be 11, 17.
 
 Example Playbook
 ----------------

--- a/roles/jws/tasks/java_install.yml
+++ b/roles/jws/tasks/java_install.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Install Java"
   when:
-    - jws_java_version is defined
+    - jws_java_home is not defined and jws_java_version is defined
     - ansible_os_family == "RedHat"
   block:
     - name: "Add 'java-{{ jws_java_version }}-openjdk-headless' to dependencies list"

--- a/roles/jws/tasks/main.yml
+++ b/roles/jws/tasks/main.yml
@@ -1,6 +1,11 @@
 ---
 # The following is only for upstream: if jws_version is not defined
 # we use the latest version of Apache Tomcat
+- name: Check for conflicting Java variables
+  fail:
+    msg: "Error: Set only one of jws_java_version or jws_java_home, not both. For better understanding check jws role README file"
+  when: jws_java_version is defined and jws_java_home is defined
+
 - name: "Set default values"
   ansible.builtin.set_fact:
     zipfile_name: "apache-tomcat-{{ tomcat_version }}.zip"
@@ -27,8 +32,7 @@
 
 - name: "Include tasks for Java installation (if Java version is provided)"
   ansible.builtin.include_tasks: java_install.yml
-  when:
-    - jws_java_version is defined
+  when: jws_java_home is not defined and jws_java_version is defined
 
 - name: "Install required dependencies"
   ansible.builtin.include_tasks: fastpackage.yml

--- a/roles/jws_validation/tasks/catalina_out.yml
+++ b/roles/jws_validation/tasks/catalina_out.yml
@@ -36,7 +36,7 @@
     quiet: true
     fail_msg: "The service is not running on the expected JVM."
   when:
-    - jws_java_version is defined
+    - jws_java_home is not defined and jws_java_version is defined
 
 - name: "Test JWS specific features"
   when:


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/AMW-133

There are two variables utilized to configure the Java Development Kit (JDK) for the jws collection. The first variable, "jws_java_version," facilitates the installation of an OpenJDK with the specified version. The alternative is to employ "jws_java_home," allowing users to specify the path to their Java installation.

Before this fix, There were two scenarios - when both variables were applied or neither were applied led to complications, resulting in a malfunctioning JWS installation. Now with this fix, we have refined the collection process. Now, if "jws_java_home" is set, "jws_java_version" will be disregarded. Additionally, if a user attempts to set both variables at the same time, then an ERROR will be triggered, prompting the termination of the operation.