### PR TITLE
Workaround AMW-185

### DIFF
--- a/roles/jws/tasks/defaults.yml
+++ b/roles/jws/tasks/defaults.yml
@@ -59,14 +59,18 @@
     - name: "Check main zipfile"
       ansible.builtin.assert:
         that:
-          - "'{{ jws_archive_repository }}/{{ zipfile_name }}' is exists"
-        fail_msg: "An offline install was requested but the zipfile {{ jws_archive_repository }}/{{ zipfile_name }} was not found"
+          - filename is exists
+        fail_msg: "An offline install was requested but the zipfile {{ filename }} was not found"
+      vars:
+        filename: "{{ jws_archive_repository }}/{{ zipfile_name }}"
     - name: "Check native zipfile exists"
       ansible.builtin.assert:
         that:
-          - "'{{ jws_archive_repository }}/{{ jws_native_zipfile }}' is exists"
-        fail_msg: "An offline install was requested but the zipfile {{ jws_archive_repository }}/{{ jws_native_zipfile }} was not found"
+          - filename is exists
+        fail_msg: "An offline install was requested but the zipfile {{ filename }} was not found"
       when: jws_native
+      vars:
+        filename: "{{ jws_archive_repository }}/{{ jws_native_zipfile }}"
     - name: "Check patch zipfile exists"
       ansible.builtin.assert:
         that:
@@ -82,4 +86,7 @@
         fail_msg: "An offline install was requested but the zipfile {{ filename }} was not found"
       when: jws_apply_patches and jws_native
       vars:
-        filename: "{{ jws_archive_repository + '/jws-' + jws_patch_version + (jws_version.startswith('6') | ternary('-optional-native-components-RHEL', '-application-server-RHEL')) + (jws_native_rhel_version | default(ansible_facts['distribution_major_version'])) + '-' + jws_patch_native_arch  + '.zip' }}"
+        filename: "{{ jws_archive_repository + '/jws-' + jws_patch_version + \
+                      (jws_version.startswith('6') | ternary('-optional-native-components-RHEL', '-application-server-RHEL')) + \
+                      (jws_native_rhel_version | default(ansible_facts['distribution_major_version'])) + \
+                      '-' + jws_patch_native_arch  + '.zip' }}"

--- a/roles/jws/tasks/install/force_install.yml
+++ b/roles/jws/tasks/install/force_install.yml
@@ -5,13 +5,13 @@
     ps --no-headers -u {{ jws.user }} | grep -v grep | awk '{print $1}'
   args:
     executable: /bin/bash
-  become: yes
+  become: True
   register: running_processes
   changed_when: False
 
 - name: "Terminate foreign processes"
   ansible.builtin.command: "kill -15 {{ running_processes.stdout_lines | join(' ') }}"
-  become: yes
+  become: True
   when:
     - jws_force_install
     - running_processes.stdout_lines | length > 0
@@ -23,14 +23,14 @@
     ps --no-headers -u {{ jws.user }} | grep -v grep | awk '{print $1}'
   args:
     executable: /bin/bash
-  become: yes
+  become: True
   failed_when: running_processes.stderr_lines | length > 0
   changed_when: False
   register: running_processes
 
 - name: "Kill foreign processes"
   ansible.builtin.command: "kill -9 {{ running_processes.stdout_lines | join(' ') }}"
-  become: yes
+  become: True
   when:
     - jws_force_install
     - running_processes.stdout_lines | length > 0


### PR DESCRIPTION
Use bare variables in defaults.yml to workaround ansible changes in https://access.redhat.com/security/cve/CVE-2023-5764  (core >= 2.14.12)