### PR TITLE
AMW-186, linter, and ansible-core >=2.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains the Ansible roles and playbooks to set up an automated 
 ## Ansible version compatibility
 
 <!--start ansible_version -->
-This collection has been tested against Ansible versions 2.9.10 or later.
+This collection has been tested against Ansible versions 2.14.0 or later.
 
 The plug-ins and modules that are within a collection might be tested with specific Ansible versions only. A collection can contain metadata that identifies these Ansible versions.
 <!--end ansible_version -->
@@ -90,7 +90,7 @@ To enable the collection to install JBoss Web Server from local archive files:
    | `native_zipfile`       | Specifies the name of the native archive file on your control node                       |
 
 > **Note:** By default, the collection installs the main application server archive only. If you also want to install the native archive, ensure that you copy the native archive file to your control node and set the `jws_native` variable to `True`.
-    
+
 > **Note:** If you did not change the archive file names, you do not need to set the `zipfile_name` and `native_zipfile` variables. The collection uses the JBoss Web Server version to determine the default file names automatically. 
 
 4. If you also want to install the latest cumulative patches for the appropriate JBoss Web Server version, copy the archive files for the latest patch updates to your Ansible control node. Then set the `jws_apply_patches` variable to `True`:
@@ -98,6 +98,9 @@ To enable the collection to install JBoss Web Server from local archive files:
         vars:
           ...
           jws_apply_patches: True
+
+> **Note:** Even when local file are present on the controller, the role tries to contact the download server to verify is new cumulative patches are available. To completely turn off
+any remote access, set the parameter `jws_offline_install: True`
 
 
 ### Using RPM packages

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.13.0"
+requires_ansible: ">=2.14.0"

--- a/roles/jws/defaults/main.yml
+++ b/roles/jws/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # comma separated list of wars to undeploy
-# ex: jws_apps_to_remove: 'docs,ROOT,examples'
+# example: jws_apps_to_remove: 'docs,ROOT,examples'
 jws_apps_to_remove: 'examples'
 # root directory of installation
 jws_install_dir: /opt
@@ -52,7 +52,7 @@ jws_conf_web: './conf/web.xml'
 jws_conf_users: 'conf/tomcat-users.xml'
 jws_conf_jaspic_providers: './conf/jaspic-providers.xml'
 jws_conf_templates_context: "templates/{{ jws_version[0:1] | default('.') }}/context.xml.j2"
-jws_conf_templates_server: "templates/{{ jws_version[0:1]  | default('.') }}/server.xml.j2"
+jws_conf_templates_server: "templates/{{ jws_version[0:1] | default('.') }}/server.xml.j2"
 jws_conf_templates_web: "templates/{{ jws_version[0:1] | default('.') }}/web.xml.j2"
 jws_conf_templates_catalina_properties: "templates/{{ jws_version[0:1] | default('.') }}/catalina.properties.j2"
 

--- a/roles/jws/meta/main.yml
+++ b/roles/jws/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
 
   license: Apache License 2.0
 
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.14"
 
   platforms:
     - name: EL

--- a/roles/jws/tasks/apply_cp/copy_cp_on_target_and_checksum.yml
+++ b/roles/jws/tasks/apply_cp/copy_cp_on_target_and_checksum.yml
@@ -12,7 +12,7 @@
     group: "{{ jws.group | default(omit) }}"
     mode: 0640
   register: new_version_downloaded
-  become: yes
+  become: True
   when:
     - patch_archive_path is defined
     - patch_archive_path.stat is defined

--- a/roles/jws/tasks/apply_cp/download_from_rhn.yml
+++ b/roles/jws/tasks/apply_cp/download_from_rhn.yml
@@ -15,7 +15,10 @@
 
     - name: Determine patch versions list
       ansible.builtin.set_fact:
-        filtered_versions: "{{ rhn_products.results | map(attribute='file_path') | select('match', '^[^/]*/jws-.*[0-9]*[.][0-9]*[.][0-9]*.*$') | map('regex_replace','[^/]*/jws-([0-9]*[.][0-9]*[.][0-9]*)-.*','\\1' ) | list | unique }}"
+        filtered_versions: "{{ rhn_products.results | map(attribute='file_path') | \
+                               select('match', '^[^/]*/jws-.*[0-9]*[.][0-9]*[.][0-9]*.*$') | \
+                               map('regex_replace', '[^/]*/jws-([0-9]*[.][0-9]*[.][0-9]*)-.*', '\\1' ) | \
+                               list | unique }}"
       when:
         - rhn_products.results is defined and rhn_products.results | length > 0
       delegate_to: localhost
@@ -31,7 +34,8 @@
 
     - name: Determine install zipfile from search results
       ansible.builtin.set_fact:
-        rhn_filtered_products: "{{ rhn_products.results | selectattr('file_path', 'match', '[^/]*/jws-' + jws_latest_version + archive_file_suffix + '$') }}"
+        rhn_filtered_products: "{{ rhn_products.results | selectattr('file_path', 'match', \
+                                   '[^/]*/jws-' + jws_latest_version + archive_file_suffix + '$') }}"
         patch_bundle: "jws-{{ jws_latest_version }}{{ archive_file_suffix }}"
         patch_version: "{{ jws_latest_version }}"
       when:
@@ -46,7 +50,8 @@
       block:
         - name: "Determine selected patch from supplied version: {{ jws_patch_version }}"
           ansible.builtin.set_fact:
-            rhn_filtered_products: "{{ rhn_products.results | selectattr('file_path', 'match', '[^/]*/jws-' + jws_patch_version + archive_file_suffix + '$') }}"
+            rhn_filtered_products: "{{ rhn_products.results | selectattr('file_path', 'match', \
+                                       '[^/]*/jws-' + jws_patch_version + archive_file_suffix + '$') }}"
             patch_bundle: "jws-{{ jws_patch_version }}{{ archive_file_suffix }}"
             patch_version: "{{ jws_patch_version }}"
           when: jws_patch_version is defined and jws_patch_version | length > 0

--- a/roles/jws/tasks/defaults.yml
+++ b/roles/jws/tasks/defaults.yml
@@ -44,11 +44,14 @@
       - rhn_username is defined and rhn_username | length > 0
       - rhn_password is defined and rhn_password | length > 0
     quiet: True
-    fail_msg: "When downloading JWS automatically from RHN, credentials are required to be set in variables rhn_username / rhn_password"
+    fail_msg: "When downloading JWS zipfiles automatically from RHN, credentials are required to be set in variables rhn_username / rhn_password"
   when:
     - jws_version is defined
     - not jws_offline_install
     - jws.install_method == 'zipfiles'
+    - (jws_apply_patches or not filename is exists)
+  vars:
+    filename: "{{ jws_archive_repository }}/{{ zipfile_name }}"
 
 - name: "Ensure zipfiles exist on controller when installing offline."
   when:
@@ -59,14 +62,18 @@
     - name: "Check main zipfile"
       ansible.builtin.assert:
         that:
-          - "'{{ jws_archive_repository }}/{{ zipfile_name }}' is exists"
-        fail_msg: "An offline install was requested but the zipfile {{ jws_archive_repository }}/{{ zipfile_name }} was not found"
+          - filename is exists
+        fail_msg: "An offline install was requested but the zipfile {{ filename }} was not found"
+      vars:
+        filename: "{{ jws_archive_repository }}/{{ zipfile_name }}"
     - name: "Check native zipfile exists"
       ansible.builtin.assert:
         that:
-          - "'{{ jws_archive_repository }}/{{ jws_native_zipfile }}' is exists"
-        fail_msg: "An offline install was requested but the zipfile {{ jws_archive_repository }}/{{ jws_native_zipfile }} was not found"
+          - filename is exists
+        fail_msg: "An offline install was requested but the zipfile {{ filename }} was not found"
       when: jws_native
+      vars:
+        filename: "{{ jws_archive_repository }}/{{ jws_native_zipfile }}"
     - name: "Check patch zipfile exists"
       ansible.builtin.assert:
         that:
@@ -82,4 +89,7 @@
         fail_msg: "An offline install was requested but the zipfile {{ filename }} was not found"
       when: jws_apply_patches and jws_native
       vars:
-        filename: "{{ jws_archive_repository + '/jws-' + jws_patch_version + (jws_version.startswith('6') | ternary('-optional-native-components-RHEL', '-application-server-RHEL')) + (jws_native_rhel_version | default(ansible_facts['distribution_major_version'])) + '-' + jws_patch_native_arch  + '.zip' }}"
+        filename: "{{ jws_archive_repository + '/jws-' + jws_patch_version + \
+                      (jws_version.startswith('6') | ternary('-optional-native-components-RHEL', '-application-server-RHEL')) + \
+                      (jws_native_rhel_version | default(ansible_facts['distribution_major_version'])) + \
+                      '-' + jws_patch_native_arch  + '.zip' }}"

--- a/roles/jws/tasks/install/deploy_archive.yml
+++ b/roles/jws/tasks/install/deploy_archive.yml
@@ -40,4 +40,4 @@
     - archive_path.stat is defined
     - not archive_path.stat.exists
     - path_to_zipfile_local is exists
-  become: yes
+  become: True

--- a/roles/jws/tasks/main.yml
+++ b/roles/jws/tasks/main.yml
@@ -2,7 +2,7 @@
 # The following is only for upstream: if jws_version is not defined
 # we use the latest version of Apache Tomcat
 - name: Check for conflicting Java variables
-  fail:
+  ansible.builtin.fail:
     msg: "Error: Set only one of jws_java_version or jws_java_home, not both. For better understanding check jws role README file"
   when: jws_java_version is defined and jws_java_home is defined
 


### PR DESCRIPTION
- ansible-core==2.13 is EOL, updating minimum version to 2.14.0
- AMW-186 do not contact JbossNetwork (ie. no credentials needed) when nto applying patches and zipfile is locally available
- linter