### PR TITLE
Update default for `jws_native`

### DIFF
--- a/roles/jws/meta/argument_specs.yml
+++ b/roles/jws/meta/argument_specs.yml
@@ -42,9 +42,9 @@ argument_specs:
                 description: "Version of JWS to install"
                 type: "str"
             jws_selinux_enabled:
-                # line 27 of jws/defaults/main.yml
-                default: True
+                default: False
                 description: "Enable selinux policy enforcement for JWS"
+                type: "bool"
             jws_dependencies_list:
                 type: "list"
                 default:
@@ -435,6 +435,10 @@ argument_specs:
             jws_selinux_enabled:
                 default: True
                 description: "Enable selinux policy enforcement for JWS"
+                type: "bool"
+            jws_native:
+                default: True
+                description: "Install native bits; provide a zipfile path below with tomcat, while on JWS it will be interpolated from version"
                 type: "bool"
             jws_product_category:
                 default: "webserver"

--- a/roles/jws/tasks/defaults.yml
+++ b/roles/jws/tasks/defaults.yml
@@ -41,6 +41,17 @@
     - jws_offline_install and jws_apply_patches
     - jws.install_method == 'zipfiles'
 
+- name: "Ensure native bits are installed when selinux policy is enabled"
+  ansible.builtin.assert:
+    that:
+      - jws_native
+    quiet: True
+    fail_msg: "In order to install the SELinux policy, native optional components are required; please set jws_native to True"
+  when:
+    - jws_version is defined
+    - jws_native is defined
+    - jws_selinux_enabled
+
 - name: "Ensure credentials are defined when installing from JBossNetwork API."
   ansible.builtin.assert:
     that:


### PR DESCRIPTION
When `jws_selinux_enabled` is set to True, `jws_native` also needs to be set to True; this changeset adds a check that verifies said condition, and updates jws_native default to True