### PR TITLE
fix typo in variable name

### DIFF
--- a/roles/jws/README.md
+++ b/roles/jws/README.md
@@ -65,7 +65,7 @@ Role Defaults
 | `jws_catalina_base`                      | Tomcat catalina base env variable        | `{{ lookup('env','CATALINA_BASE') }}`         |
 | `jws_conf_properties`                    | Path for tomcat configuration            | `./conf/catalina.properties`                  |
 | `jws_conf_policy`                        | Path for tomcat policy configuration     | `./conf/catalina.policy`                      |
-| `jws_conf_loggging`                      | Path for logging configuration           | `./conf/logging.properties`                   |
+| `jws_conf_logging`                       | Path for logging configuration           | `./conf/logging.properties`                   |
 | `jws_conf_context`                       | Relative path to context.xml             | `./conf/context.xml`                          |
 | `jws_conf_server`                        | Relative path to server.xml              | `./conf/server.xml`                           |
 | `jws_conf_web`                           | Relative path to web.xml                 | `./conf/web.xml`                              |

--- a/roles/jws/defaults/main.yml
+++ b/roles/jws/defaults/main.yml
@@ -48,7 +48,7 @@ jws_setup: True
 jws_catalina_base: "{{ lookup('env', 'CATALINA_BASE') }}"
 jws_conf_properties: './conf/catalina.properties'
 jws_conf_policy: './conf/catalina.policy'
-jws_conf_loggging: './conf/logging.properties'
+jws_conf_logging: './conf/logging.properties'
 jws_conf_context: './conf/context.xml'
 jws_conf_server: './conf/server.xml'
 jws_conf_web: './conf/web.xml'

--- a/roles/jws/meta/argument_specs.yml
+++ b/roles/jws/meta/argument_specs.yml
@@ -108,7 +108,7 @@ argument_specs:
                 default: "./conf/catalina.policy"
                 description: "Path for tomcat policy configuration"
                 type: "str"
-            jws_conf_loggging:
+            jws_conf_logging:
                 # line 13 of jws/defaults/main.yml
                 default: "./conf/logging.properties"
                 description: "Path for logging configuration"

--- a/roles/jws/vars/main.yml
+++ b/roles/jws/vars/main.yml
@@ -14,7 +14,7 @@ jws:
   conf:
     properties: "{{ jws_conf_properties }}"
     policy: "{{ jws_conf_policy }}"
-    logging: "{{ jws_conf_loggging }}"
+    logging: "{{ jws_conf_logging }}"
     context: "{{ jws_conf_context }}"
     server: "{{ jws_conf_server }}"
     web: "{{ jws_conf_web }}"


### PR DESCRIPTION
The role parameter `jws_conf_loggging` contains a spelling error. This change renames the parameter to `jws_conf_logging`.