### PR TITLE
Fix linter warnings for the jws role

### DIFF
--- a/roles/jws/defaults/main.yml
+++ b/roles/jws/defaults/main.yml
@@ -35,7 +35,7 @@ jws_install_download_archive_require_privilege_escalation: True
 jws_install_unarchive_require_privilege_escalation: True
 
 # Default version of Apache Tomcat to use if no version is provided
-tomcat_version: 10.1.13
+tomcat_version: 10.1.13  # noqa var-naming[no-role-prefix]
 # Switch to True if you want to also download native bits
 jws_native: False
 jws_native_zipfile: ''

--- a/roles/jws/tasks/fastpackage.yml
+++ b/roles/jws/tasks/fastpackage.yml
@@ -11,7 +11,7 @@
 
 - name: "Install packages: {{ packages_to_install }}"
   become: True
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "{{ packages_to_install }}"
     state: present
   when: packages_to_install | default([]) | length > 0

--- a/roles/jws/tasks/rhn/search.yml
+++ b/roles/jws/tasks/rhn/search.yml
@@ -22,7 +22,7 @@
   become: "{{ rhn_download_become | default(false) }}"
   run_once: true
 
-- name: "Determine results matching the file suffix {{ rhn_file_suffix  | default('') }}"
+- name: "Determine results matching the file suffix {{ rhn_file_suffix | default('') }}"
   ansible.builtin.set_fact:
     filtered_results: "{{ rhn_products.results | default([]) | map(attribute='file_path') | \
                           select('match', '^[^/]*/jws-.*' + rhn_file_suffix | default('') + '.*$') | \

--- a/roles/jws/vars/main.yml
+++ b/roles/jws/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-jws:
+jws:  # noqa var-naming[no-role-prefix]
   supported_install_method: [zipfiles, rpm]
   install_method: "{{ jws_install_method }}"
   install_dir: "{{ jws_install_dir }}"


### PR DESCRIPTION
There are still warnings for the validation role, which is probably not so important.